### PR TITLE
Change messages to message

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ function DogPics() {
       .then((r) => r.json())
       .then((data) => {
         // setting state in the useEffect callback
-        setImages(data.messages);
+        setImages(data.message);
       });
   });
 
@@ -225,7 +225,7 @@ useEffect(() => {
   fetch("https://dog.ceo/api/breeds/image/random/3")
     .then((r) => r.json())
     .then((data) => {
-      setImages(data.messages);
+      setImages(data.message);
     });
 }, []);
 ```


### PR DESCRIPTION

![Screen Shot 2021-06-21 at 9 08 48 AM](https://user-images.githubusercontent.com/28542439/122793697-5a6a0600-d270-11eb-9c90-e6d274c30219.png)
The dog api returns its data with a key of `message`, not `messages` for any students who are coding along to this readme.